### PR TITLE
hotfix: 충고 답변에서 SYMPATHY(공감) 타입으로 저장되는 에러 수정

### DIFF
--- a/src/main/generated/uni/capstone/moodmingle/member/application/dto/MemberCommandMapperImpl.java
+++ b/src/main/generated/uni/capstone/moodmingle/member/application/dto/MemberCommandMapperImpl.java
@@ -8,7 +8,7 @@ import uni.capstone.moodmingle.member.domain.Member.MemberBuilder;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-05-22T16:53:44+0900",
+    date = "2024-05-22T21:15:40+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.5 (JetBrains s.r.o.)"
 )
 @Component

--- a/src/main/java/uni/capstone/moodmingle/diary/infra/ReplyGPTClient.java
+++ b/src/main/java/uni/capstone/moodmingle/diary/infra/ReplyGPTClient.java
@@ -82,7 +82,7 @@ public class ReplyGPTClient implements LLMClient {
      */
     @Override
     public void requestAdvicePhrase(List<GptMessage> prompts, Long diaryId) {
-        requestToGptApi(adviceAPIModel, adviceApiKey, prompts, diaryId, Type.SYMPATHY);
+        requestToGptApi(adviceAPIModel, adviceApiKey, prompts, diaryId, Type.ADVICE);
     }
 
     /**


### PR DESCRIPTION
충고 답변에서 SYMPATHY(공감) 타입으로 저장되는 에러 수정