### PR TITLE
OpenAI API서버의 장기간 장애 대응을 위한 CircuitBreaker 도입

### DIFF
--- a/src/test/java/uni/capstone/moodmingle/clients/circuitbreaker/CircuitBreakTest.java
+++ b/src/test/java/uni/capstone/moodmingle/clients/circuitbreaker/CircuitBreakTest.java
@@ -1,0 +1,32 @@
+package uni.capstone.moodmingle.clients.circuitbreaker;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.junit.jupiter.api.Test;
+import uni.capstone.moodmingle.global.error.ErrorCode;
+import uni.capstone.moodmingle.global.error.exception.ExternalApiException;
+
+public class CircuitBreakTest {
+
+    @Test
+    public void 서킷브레이커_테스트() {
+
+        for (int i = 0; i < 10; i++) {
+            try {
+                circuitBreakerMethods();
+            } catch (Exception e) {
+                System.out.println(i + "번째 요청 실패");
+            }
+        }
+    }
+
+    @CircuitBreaker(name = "openai-api", fallbackMethod = "circuitBreakerCallbackMethod")
+    private void circuitBreakerMethods() {
+        throw new ExternalApiException(ErrorCode.FAILED_IO_OPERATION);
+    }
+
+    // ✅ 서킷브레이커 오픈됐을 때 실행되는 fallback
+    private void circuitBreakerCallbackMethod(Throwable error) {
+        System.out.println("서킷 브레이커 OPEN 상태. 요청 차단됨.");
+        throw new ExternalApiException(ErrorCode.CIRCUIT_BREAKER_OPENED);
+    }
+}

--- a/src/test/java/uni/capstone/moodmingle/clients/reactive/AsyncTest.java
+++ b/src/test/java/uni/capstone/moodmingle/clients/reactive/AsyncTest.java
@@ -1,0 +1,67 @@
+package uni.capstone.moodmingle.clients.reactive;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+public class AsyncTest {
+
+    @Test
+    public void Mono_테스트() {
+        // Mono Publisher 생성해서 Subscriber 로 핸들링해보기
+        Mono<String> mono = Mono.just("Hello, Mono!");
+        mono.subscribe(data -> System.out.println("모노보노: " + data));
+
+        // 핸들링
+        Mono<String> emptyMono = Mono.empty();
+        emptyMono.subscribe(
+                data -> System.out.println("응답: " + data),
+                error -> System.out.println("에러: " + error),
+                () -> System.out.println("완료!")
+        );
+
+        // Mono 는 데이터를 변환하거나 가공하기 위해 다양한 연산자 제공
+        // 1. map
+        Mono<String> lowerMono = Mono.just("HELLO")
+                .map(data -> data.toLowerCase());
+        lowerMono.subscribe(data -> System.out.println("응답 : " + data));
+        // 2. flatMap
+        Mono<String> upperMono = Mono.just("hello")
+                .flatMap(data -> Mono.just(data.toUpperCase()));
+        upperMono.subscribe(data -> System.out.println("응답 : " + data));
+        // 3. filter
+        Mono<String> filterMono = Mono.just("hello")
+                .filter(data -> data.length() > 10);
+        filterMono.subscribe(
+                data -> System.out.println("응답 : " + data),
+                error -> System.out.println("에러 : " + error),
+                () -> System.out.println("데이터 없음")
+        );
+        // 4. doOnNext()
+        Mono<String> nextMono = Mono.just("hello")
+                .doOnNext(data -> System.out.println(data + " world!"));
+        nextMono.subscribe(data -> System.out.println("응답 : " + data));
+        // 5. retry()
+        Mono<Object> errorMono = Mono.just("I will try .retry() and Mono Exception Test")
+                .doOnNext(data -> System.out.println(data + " - OK"))
+                .flatMap(data -> Mono.error(new RuntimeException("모노 런타임 예외 발생")))
+                .retry(3);
+        errorMono.subscribe(
+                data -> System.out.println("응답: " + data),
+                error -> System.out.println("에러 발생: " + error.getMessage())
+        );
+    }
+
+    @Test
+    public void 요청_로그_테스트() {
+        // 5. retry()
+        Mono<Object> errorMono = Mono.just("로깅 테스트")
+                .flatMap(data -> Mono.error(new RuntimeException("모노 런타임 예외 발생")))
+                .doOnError(data -> System.out.println("실패!!!!"))
+                .flatMap(data -> Mono.error(new RuntimeException("모노 런타임 예외 발생")))
+                .retry(3);
+        errorMono.subscribe(
+                data -> System.out.println("응답: " + data),
+                error -> System.out.println("에러 발생: " + error.getMessage())
+        );
+    }
+}


### PR DESCRIPTION
## 👨🏻‍💻 AS-IS

### OpenAI API 서버 장애에 대한 대응 부족

- 이전에 재시도 정책에 대한 주기를 조정하였지만, 여전히 **OpenAI API 서버가 장기적으로 N분 이상 장애 발생하는 경우에도 계속해서 불필요한 요청을 시도하는 문제**가 있습니다.

- 따라서, OpenAI API 서버 장애가 발생했을 때 이를 감지하고 **클라이언트의 요청을 차단해 불필요한 요청으로 저희 서버에 영향이 가는 것을 방지할 수 있는 대책**이 있다면 좋을 것입니다.

<br></br>

## ✍️ CircuitBreaker 도입

### 서킷브레이커(CircuitBreaker)란?

- **서킷브레이커**는 해석 그대로 누전 차단기라는 뜻을 지닙니다. 누전 차단기는 전기 회로에서 과부하가 걸리거나 단락으로 인한 피해를 막기 위해 자동으로 회로를 정지시키는 장치입니다.

- 서버에서 사용하는 **서킷브레이커**도 **외부 API 통신의 장애 전파를 막기 위해 장애를 탐지하면 외부와의 통신을 차단**하는 역할을 합니다.

- 서킷브레이커가 실행(오픈)되면 **Fail Fast 함으로써 외부 서비스가 장애가 나더라도 빠르게 에러를 응답** 받을 수 있는 장점이 있으며 개발자가 **지정한 행위를 리턴** 받을 수 있습니다.

### 서킷브레이커의 상태

서킷 브레이커는 다음과 같은 상태를 지닙니다.
상태 | 설명
-- | --
CLOSED | 정상 상태, 모든 요청 허용
OPEN | 장애 발생 → 일정 시간 동안 모든 요청 차단
HALF-OPEN | 장애 발생 → 일정 시간 동안 모든 요청 차단

### 서킷브레이커의 동작

**서킷브레이커는 외부 API와 통신에서 실패를 감지하고 상태를 조정해 요청을 사전에 차단합니다.**

    ▶︎ 외부 API 통신 시도
    ▶︎ 외부 통신이 실패함으로써 서킷브레이커 Open
    ▶︎ Open과 동시에 외부 서버에 요청을 날리지 않고, Fail Fast로 빠른응답 리턴
    ▶︎ 서킷브레이커가 오픈하면 일정 시간 후에 반오픈(Half-Open) 상태
    ▶︎ 반오픈 상태에서 다시 외부 서비스를 호출해서 장애를 확인하면 Open, 정상 응답이면 닫힘

**통신 과정에서는 어떠한 규칙으로 서킷브레이커가 열리고, 닫힐지 조정할 수 있습니다.**

---
![image](https://github.com/user-attachments/assets/d9b8d471-3067-4ec5-80d0-4e207ef6915a)

<br></br>
## ✨ TO-BE
### Resilience4j 채택

- Spring에서 간편하게 CircuitBreaker를 적용할 수 있는 `Resilience4j` 라이브러리를 사용했습니다.

    ``` javascript
    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
    ```
    
### application.yml 으로 서킷브레이커 설정

- `slidingWindowSize` : 장애를 판단할 요청 개수 기준 설정
- `failureRateThreshold` : N% 이상 실패하면 Open할 비율 N 설정
- `waitDurationInOpenState` : Open ⇒ Half-Open 으로 변경할 시간 설정

    ``` javascript
    resilience4j:
    circuitbreaker:
    instances:
      openai-api:
        slidingWindowSize: 10         # 최근 10개 요청 기준으로 장애율 계산
        failureRateThreshold: 50      # 50% 이상 실패하면 서킷 오픈
        waitDurationInOpenState: 30s  # 30초 후 Half-Open 상태로 변경
    ```

### OpenAI API 요청 메서드에 적용

- `CircuitBreaker`는 **AOP 기반으로 동작**하기 때문에 **콜백함수와 함께 요청 메서드에 어노테이션으로 적용**하면 된다!

- **요청 로직**

    ``` java
    @CircuitBreaker(name = "openai-api", fallbackMethod = "logAndSaveCircuitBreakerErrorMessages")
    private void requestToGptApi(String model,List<GptMessage> messages, Long diaryId, Reply.Type type) {
        ..
    }
    ```

- **콜백함수**

   - `RuntimeException`을 상속하는 `ExternalApiException`을 반환.
   
   - 로그 기록 및 저장

          ``` java
          // 서킷브레이커 오픈됐을 때
          private void logAndSaveCircuitBreakerErrorMessages(Throwable error, Long diaryId) {
              // 로그 및 저장
              String circuitBreakerLog = "🔴 OpenAI API 장애 지속: 서킷 브레이커 OPEN 상태. 요청 차단됨.";
              log.error(circuitBreakerLog);
              createAndSaveFailedLog(circuitBreakerLog, diaryId);
          
              // 예외
              throw new ExternalApiException(ErrorCode.CIRCUIT_BREAKER_OPENED);
          }
          ```