### PR TITLE
OpenAI API 서버 장애가 전파되는 상황을 방지하기 위한 서킷브레이커 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,9 +86,6 @@ dependencies {
 	// AWS KMS
 	implementation 'com.amazonaws:aws-java-sdk-kms:1.12.711'
 	implementation 'com.amazonaws:aws-java-sdk-core:1.12.711'
-
-	// CircuitBreaker
-	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/generated/uni/capstone/moodmingle/domain/diary/application/dto/DiaryCommandMapperImpl.java
+++ b/src/main/generated/uni/capstone/moodmingle/domain/diary/application/dto/DiaryCommandMapperImpl.java
@@ -15,7 +15,7 @@ import uni.capstone.moodmingle.domain.member.domain.Member;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2025-03-16T13:40:13+0900",
+    date = "2025-03-20T21:16:54+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.11 (Amazon.com Inc.)"
 )
 @Component

--- a/src/main/generated/uni/capstone/moodmingle/domain/diary/presentation/dto/DiaryDtoMapperImpl.java
+++ b/src/main/generated/uni/capstone/moodmingle/domain/diary/presentation/dto/DiaryDtoMapperImpl.java
@@ -11,7 +11,7 @@ import uni.capstone.moodmingle.domain.diary.presentation.dto.request.DiaryCreate
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2025-03-16T13:40:13+0900",
+    date = "2025-03-20T21:16:54+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.11 (Amazon.com Inc.)"
 )
 @Component

--- a/src/main/generated/uni/capstone/moodmingle/domain/member/application/dto/MemberCommandMapperImpl.java
+++ b/src/main/generated/uni/capstone/moodmingle/domain/member/application/dto/MemberCommandMapperImpl.java
@@ -8,7 +8,7 @@ import uni.capstone.moodmingle.domain.member.domain.Member.MemberBuilder;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2025-03-16T13:40:13+0900",
+    date = "2025-03-20T21:16:54+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.11 (Amazon.com Inc.)"
 )
 @Component

--- a/src/main/generated/uni/capstone/moodmingle/domain/member/presentation/dto/MemberDtoMapperImpl.java
+++ b/src/main/generated/uni/capstone/moodmingle/domain/member/presentation/dto/MemberDtoMapperImpl.java
@@ -8,7 +8,7 @@ import uni.capstone.moodmingle.global.security.oidc.entity.OidcUserInfo;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2025-03-16T13:40:13+0900",
+    date = "2025-03-20T21:16:54+0900",
     comments = "version: 1.4.2.Final, compiler: javac, environment: Java 17.0.11 (Amazon.com Inc.)"
 )
 @Component

--- a/src/main/java/uni/capstone/moodmingle/MoodMingleApplication.java
+++ b/src/main/java/uni/capstone/moodmingle/MoodMingleApplication.java
@@ -5,7 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableCaching
 @EnableFeignClients
 @EnableJpaAuditing

--- a/src/main/java/uni/capstone/moodmingle/clients/llm/gpt/GptClient.java
+++ b/src/main/java/uni/capstone/moodmingle/clients/llm/gpt/GptClient.java
@@ -1,6 +1,5 @@
 package uni.capstone.moodmingle.clients.llm.gpt;
 
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jboss.logging.MDC;
@@ -8,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.util.retry.Retry;
+import uni.capstone.moodmingle.clients.llm.gpt.circuitbreaker.GptCircuitBreaker;
 import uni.capstone.moodmingle.clients.llm.gpt.dto.GptMessage;
 import uni.capstone.moodmingle.clients.llm.gpt.dto.GptResponseInfo;
 import uni.capstone.moodmingle.clients.llm.gpt.facade.PromptProcessingFacade;
@@ -42,6 +42,7 @@ public class GptClient {
     private String gptApiModel;
 
     private final WebClient gptWebClient;
+    private final GptCircuitBreaker gptCircuitBreaker;
     private final FailedLogRepository failedLogRepository;
     private final ReplyHandlerService handler;
     private final PromptProcessingFacade processingFacade;
@@ -71,15 +72,17 @@ public class GptClient {
      * @param messages Prompt Messages
      * @param type 답장 Type
      */
-    @CircuitBreaker(name = "openai-api", fallbackMethod = "logAndSaveCircuitBreakerErrorMessages")
-    private void requestToGptApi(String model,List<GptMessage> messages, Long diaryId, Reply.Type type) {
-        // OpenAI API 요청하기 위한 HTTP Body
-        Map<String, Object> bodyMap = processOpenAIRequestBody(model, messages);
+    public void requestToGptApi(String model, List<GptMessage> messages, Long diaryId, Reply.Type type) {
+        // 서킷 브레이커 상태 확인
+        if (gptCircuitBreaker.checkCircuitBreakerOpened()) {
+            throw new ExternalApiException(ErrorCode.CIRCUIT_BREAKER_OPENED);
+        }
+
         // OpenAI API 요청
         gptWebClient
                 .post()
                 .uri(gptRequestUrl)
-                .bodyValue(bodyMap)
+                .bodyValue(processOpenAIRequestBody(model, messages))
                 .retrieve()
                 .bodyToMono(GptResponseInfo.class)
                 .doOnEach(signal -> {
@@ -97,7 +100,10 @@ public class GptClient {
                 .doFinally(signal -> MDC.clear())              // 식별자 메모리에서 비우기
                 .subscribe(
                         gptResponse -> handler.createAndSaveReply(diaryId, gptResponse, type),
-                        error -> handler.treatFailedReplyDiary(diaryId)
+                        error -> {
+                            handler.treatFailedReplyDiary(diaryId);
+                            gptCircuitBreaker.addFailureCount();        // 실패 횟수 추가
+                        }
                 );
     }
 
@@ -105,17 +111,6 @@ public class GptClient {
     private void putRequestId() {
         String requestId = UUID.randomUUID().toString().substring(0, 8);
         MDC.put("requestId", requestId);
-    }
-
-    // 서킷브레이커 오픈됐을 때
-    private void logAndSaveCircuitBreakerErrorMessages(Throwable error, Long diaryId) {
-        // 로그 및 저장
-        String circuitBreakerLog = "🔴 OpenAI API 장애 지속: 서킷 브레이커 OPEN 상태. 요청 차단됨.";
-        log.error(circuitBreakerLog);
-        createAndSaveFailedLog(circuitBreakerLog, diaryId);
-
-        // 예외
-        throw new ExternalApiException(ErrorCode.CIRCUIT_BREAKER_OPENED);
     }
 
     // OpenAI API 통신 실패했을 때

--- a/src/main/java/uni/capstone/moodmingle/clients/llm/gpt/circuitbreaker/GptCircuitBreaker.java
+++ b/src/main/java/uni/capstone/moodmingle/clients/llm/gpt/circuitbreaker/GptCircuitBreaker.java
@@ -1,0 +1,48 @@
+package uni.capstone.moodmingle.clients.llm.gpt.circuitbreaker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GptCircuitBreaker {
+
+    private final GptStatusTestClient gptStatusTestClient;
+    private static CircuitBreakerStatus status = CircuitBreakerStatus.CLOSED;
+    private int failureCount = 0;
+
+    // 상태 조회
+    public synchronized boolean checkCircuitBreakerOpened() {
+        return status == CircuitBreakerStatus.OPEN;
+    }
+
+    // 실패 횟수 +1
+    public synchronized void addFailureCount() {
+        failureCount += 1;
+        log.info("✅️실패 카운팅 : " + failureCount);
+        if (failureCount > 10) {
+            log.info("‼️서킷브레이커 오픈 ‼️");
+            status = CircuitBreakerStatus.OPEN;
+        }
+    }
+
+    // 10분마다 GPT API 상태 확인
+    @Scheduled(fixedRate = 600000)
+    public void testGptApiStatus() {
+        if (status == CircuitBreakerStatus.OPEN) {
+            if (gptStatusTestClient.requestToGptApi()) {        // 요청해서 200 응답이면 서킷브레이커 CLOSED 변환, 실패횟수 초기화
+                status = CircuitBreakerStatus.CLOSED;
+                failureCount = 0;
+                log.info("‼️서킷브레이커 다시 닫힘 ‼️, 실패카운트 : " + failureCount);
+            }
+        }
+    }
+}
+
+enum CircuitBreakerStatus {
+    CLOSED,
+    OPEN
+}

--- a/src/main/java/uni/capstone/moodmingle/clients/llm/gpt/circuitbreaker/GptStatusTestClient.java
+++ b/src/main/java/uni/capstone/moodmingle/clients/llm/gpt/circuitbreaker/GptStatusTestClient.java
@@ -1,0 +1,63 @@
+package uni.capstone.moodmingle.clients.llm.gpt.circuitbreaker;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import uni.capstone.moodmingle.clients.llm.gpt.dto.GptMessage;
+import uni.capstone.moodmingle.clients.llm.gpt.dto.GptResponseInfo;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class GptStatusTestClient {
+
+    // OpenAI API 설정값
+    @Value("${openai.api.url}")
+    private String gptRequestUrl;
+    @Value("${openai.api.model}")
+    private String gptApiModel;
+
+    private final WebClient gptWebClient;
+
+    // GPT API 테스트
+    public Boolean requestToGptApi() {
+        Map<String, Object> bodyMap = processOpenAIRequestBody();
+        try {
+            gptWebClient
+                    .post()
+                    .uri(gptRequestUrl)
+                    .bodyValue(bodyMap)
+                    .retrieve()
+                    .bodyToMono(GptResponseInfo.class)
+                    .block();
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
+    // OpenAI API 요청 데이터 가공
+    private Map<String, Object> processOpenAIRequestBody() {
+        Map<String, Object> bodyMap = new HashMap<>();
+        bodyMap.put("model", gptApiModel);
+        bodyMap.put("stream", false);
+        bodyMap.put("messages", processTestMessages());
+        bodyMap.put("temperature", 1.0);
+        return bodyMap;
+    }
+
+    private List<GptMessage> processTestMessages() {
+        List<GptMessage> messages = new ArrayList<>();
+        GptMessage message = GptMessage.builder()
+                .role("user")
+                .content("Hello!")
+                .build();
+        messages.add(message);
+        return messages;
+    }
+}


### PR DESCRIPTION
MoodMingle 서버가 OpenAI 서버의 장애를 인식하지 못해 **클라이언트의 요청을 계속 받고, 이로 인해 트래픽이 쌓여 OpenAI API 장애가 MoodMingle 서버까지 전파**될 위험이 있었습니다.
    
   - 서킷 브레이커를 직접 구현해 **임계치(10회)를 초과하면 OPEN 상태로 전환해 클라이언트의 추가 요청을 차단**했습니다.
    
   - `@Scheduled`를 통해 **10분마다 GPT API의 정상 응답 여부를 테스트**해, 응답이 정상인 경우 서킷 브레이커를 **CLOSED 상태로 복구하고 실패 카운트를 초기화**하여 OpenAI API 서버 장애에 유연하게 대처하는 서버를 구축했습니다.

   - 링크 : https://rigorous-lentil-508.notion.site/OpenAI-API-CircuitBreaker-1bb635979cdd806ea9dbd77a04c4f1c7?pvs=4